### PR TITLE
allow nil logger

### DIFF
--- a/webauth.go
+++ b/webauth.go
@@ -96,6 +96,9 @@ func New(ctx context.Context, cfg Config) (Authenticator, error) {
 			return Authenticator{}, errors.Wrap(err, "unable to init KMS client")
 		}
 	}
+	if cfg.Logger == nil {
+		cfg.Logger = log.NewNopLogger()
+	}
 	return Authenticator{
 		cfg:          cfg,
 		keys:         keys,


### PR DESCRIPTION
If a user accidentally passes a nil logger, things will panic with a nil pointer exception. We should either let them pass nil, and we fill it as a NopLogger, or update the function signature to return an error saying a logger is required. 

Either way is cool 👍 